### PR TITLE
fix small bug: plain text attachments are not parsed correctly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,7 @@ module.exports = function parseMessage(response) {
 
     if (contentType.indexOf('text/html') !== -1) {
       result.textHtml = urlB64Decode(part.body.data);
-    } else if (contentType.indexOf('text/plain') !== -1) {
+    } else if (contentType.indexOf('text/plain') !== -1 && contentDisposition.indexOf('attachment') === -1) {
       result.textPlain = urlB64Decode(part.body.data);
     } else if (contentDisposition.indexOf('attachment') !== -1) {
       var body = part.body;

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@ var parseMessage = require('../lib');
 var plainTextMessage = require('./messages/plainTextMessage');
 var multipartAlternativeMessage = require('./messages/multipartAlternativeMessage');
 var multipartAlternativeWithAttachmentsMessage = require('./messages/multipartAlternativeWithAttachmentsMessage');
+var multipartAlternativePlainTextAttachmentMessage = require('./messages/multipartAlternativePlainTextAttachmentMessage');
 var multipartAlternativeDraft = require('./messages/multipartAlternativeDraft');
 
 describe('#parse', function() {
@@ -24,7 +25,14 @@ describe('#parse', function() {
     parsedMessage.attachments.should.have.deep.property('[1].filename', 'feelthebern.jpg');
   });
 
-  it('can parse a multipart alternative draft', function () {
+  it('can parse a multipart alternative message with plain text attachments', function () {
+    var parsedMessage = parseMessage(multipartAlternativePlainTextAttachmentMessage);
+    parsedMessage.textHtml.should.equal('<div dir="ltr">cool <b>stuff</b></div>\r\n');
+    parsedMessage.textPlain.should.equal('cool *stuff*\r\n');
+    parsedMessage.attachments.should.have.deep.property('[0].filename', 'a_text_file.txt');
+  });
+
+    it('can parse a multipart alternative draft', function () {
     var parsedDraft = parseMessage(multipartAlternativeDraft.message);
     parsedDraft.textHtml.should.equal('<div dir="ltr">Can it parse <b>draft </b>now? Sure can!</div>\r\n');
     parsedDraft.textPlain.should.equal('Can it parse *draft *now? Sure can!\r\n');

--- a/test/messages/multipartAlternativePlainTextAttachmentMessage.js
+++ b/test/messages/multipartAlternativePlainTextAttachmentMessage.js
@@ -1,0 +1,69 @@
+module.exports = {
+    "id": "156576c760d1abcd",
+    "threadId": "156576c760d1bcde",
+    "labelIds": ["IMPORTANT", "SENT"],
+    "snippet": "as noted",
+    "historyId": "2163423",
+    "internalDate": "1470345541000",
+    "payload": {
+        "mimeType": "multipart/mixed",
+        "filename": "",
+        "headers": [
+            {"name": "MIME-Version", "value": "1.0"},
+            {"name": "Received", "value": "by 10.176.69.69 with HTTP; Thu, 4 Aug 2016 14:19:01 -0700 (PDT)"},
+            {"name": "Date", "value": "Thu, 4 Aug 2016 14:19:01 -0700"},
+            {"name": "Delivered-To", "value": "example@gmail.com"},
+            {"name": "Message-ID", "value": "<CADsZLRz2FotpnMzCOj_ETjC7eyNKXov_YxLw785MGpuWAiq88w@mail.gmail.com>"},
+            {"name": "Subject", "value": "text attached"},
+            {"name": "From", "value": "example <example@gmail.com>"},
+            {"name": "To", "value": "example <example@gmail.com>"},
+            {"name": "Content-Type", "value": "multipart/mixed; boundary=94eb2c18eda0b27eba0539457f0b"}
+        ],
+        "body": {"size": 0},
+        "parts": [
+            {
+                "mimeType": "multipart/alternative",
+                "filename": "",
+                "headers": [
+                    {"name": "Content-Type", "value": "multipart/alternative; boundary=089e01494ea0df3f8b0527d5ee02"}
+                ],
+                "body": {
+                    "size": 0
+                },
+                "parts": [{
+                    "partId": "0.0",
+                    "mimeType": "text/plain",
+                    "filename": "",
+                    "headers": [
+                        {"name": "Content-Type", "value": "text/plain; charset=UTF-8"}
+                    ],
+                    "body": {"size": 14, "data": "Y29vbCAqc3R1ZmYqDQo="}
+                },
+                    {
+                        "partId": "0.1",
+                        "mimeType": "text/html",
+                        "filename": "",
+                        "headers": [
+                            {"name": "Content-Type", "value": "text/html; charset=UTF-8"}
+                        ],
+                        "body": {"size": 40, "data": "PGRpdiBkaXI9Imx0ciI-Y29vbCA8Yj5zdHVmZjwvYj48L2Rpdj4NCg=="}
+                    }]
+            },
+            {
+                "partId": "1",
+                "mimeType": "text/plain",
+                "filename": "a_text_file.txt",
+                "headers": [
+                    {"name": "Content-Type", "value": "text/plain; charset=UTF-8; name=\"a_text_file.txt\""},
+                    {"name": "Content-Disposition", "value": "attachment; filename=\"a_text_file.txt\""},
+                    {"name": "Content-Transfer-Encoding", "value": "base64"},
+                    {"name": "X-Attachment-Id", "value": "f_irgtrql20"}
+                ],
+                "body": {
+                    "attachmentId": "ANGjdJ_Pic3qhYeU9X5cDL1BwF7qhARqZLU4ACc9duXq4QymaqacConJON0VXcsn1xE72Jx0PSL2Hsi_lkZSGn-UfMjw-SrkXvjYPWO_DD0vq3E4O5kVKvVtD5ZvmYiUSprOeRcrXzL6qbXF7knouIbu0-g6d-2d9AqdayzYERE-iZ28E2jKQnmWFJHRCxhY6TD8WywSbqGz78EKLBfNLczh1HqCanJqzhbocyJgKeqKo6vq2PyVa6XP-l0choox15hnJRU3LJqpziOxRO8P6gPBwmfF0_1HZ1YWBy1xFIHbWvRFjrjXZHTSrVQ-GJ4",
+                    "size": 277400
+                }
+            }]
+    },
+    "sizeEstimate": 380677
+};


### PR DESCRIPTION
Text file attachments were being treated as plain text body content and failing to parse with the following error.

```
 TypeError: Cannot read property 'replace' of undefined
      at urlB64Decode (lib/index.js:13:52)
      at parseMessage (lib/index.js:74:26)
      at Context.<anonymous> (test/index.js:29:29)
```

Small pull request (added a test case) to address.