### PR TITLE
Parse addresses

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,8 +38,9 @@ function parseAddresses(headers) {
   if (!headers) {
     return {};
   } else {
-    console.log('parseAddresses(headers): ', headers);
+    console.log('parseAddresses - input: ', headers);
     var parsedFrom = addressparser(headers.from)[0];
+    console.log('parsedFrom: ', parsedFrom);    
     headers.from = {
       name: parsedFrom.name || '',
       address: parsedFrom.address.toLowerCase()

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ function parseAddresses(headers) {
     return {};
   } else {
     console.log('parseAddresses(headers): ', headers, headers.headers);
-    var parsedFrom = addressparser(headers.from);
+    var parsedFrom = addressparser(headers.from)[0];
     headers.from = {
       name: parsedFrom.name || '',
       address: parsedFrom.address.toLowerCase()

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,7 @@ function parseAddresses(headers) {
       headers.bcc[w].address = headers.bcc[w].address.toLowerCase();
     }
 
-    return result;
+    return headers;
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 var b64Decode = require('base-64').decode;
+var addressparser = require('addressparser');
 
 /**
  * Decodes a url safe Base64 string to its original representation.
@@ -29,6 +30,44 @@ function indexHeaders(headers) {
 }
 
 /**
+ * Transforms the header email address into an object containing the name and email address
+ * @param  {array} headers
+ * @return {name: '', address: ''}
+ */
+function parseAddresses(headers) {
+  if (!headers) {
+    return {};
+  } else {
+    var parsedFrom = addressparser(headers.from)[0];
+    headers.from = {
+      name: parsedFrom.name || '',
+      address: parsedFrom.address.toLowerCase()
+    };
+    if (headers.from.name === '' || headers.from.name === ' ') {
+      headers.from.name = headers.from.address.toLowerCase();
+    }
+  
+    headers.to = addressparser(headers.to);
+    for (var u = 0; u < headers.to.length; u++) {
+      headers.to[u].address = headers.to[u].address.toLowerCase();
+    }
+  
+    headers.cc = addressparser(headers.cc);
+    for (var w = 0; w < email.cc.length; w++) {
+      headers.cc[w].address = headers.cc[w].address.toLowerCase();
+    }
+  
+    headers.bcc = addressparser(headers.bcc);
+    for (var w = 0; w < email.bcc.length; w++) {
+      headers.bcc[w].address = headers.bcc[w].address.toLowerCase();
+    }
+
+    return result;
+  }
+}
+
+
+/**
  * Takes a response from the Gmail API's GET message method and extracts all
  * the relevant data.
  * @param  {object} response
@@ -52,6 +91,7 @@ module.exports = function parseMessage(response) {
   }
 
   var headers = indexHeaders(payload.headers);
+  headers = parseAddresses(payload.headers);
   result.headers = headers;
 
   var parts = [payload];

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ function parseAddresses(headers) {
   if (!headers) {
     return {};
   } else {
-    console.log('headers', headers);
+    console.log('parseAddresses(headers): ', headers, headers.headers);
     var parsedFrom = addressparser(headers.from);
     headers.from = {
       name: parsedFrom.name || '',
@@ -92,8 +92,8 @@ module.exports = function parseMessage(response) {
   }
 
   var headers = indexHeaders(payload.headers);
-  headers = parseAddresses(headers);
-  result.headers = headers;
+  parsedHeaders = parseAddresses(headers);
+  result.headers = parsedHeaders;
 
   var parts = [payload];
   var firstPartProcessed = false;

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ function parseAddresses(headers) {
   if (!headers) {
     return {};
   } else {
-    console.log('headers.from', headers.from);
+    console.log('headers', headers);
     var parsedFrom = addressparser(headers.from);
     headers.from = {
       name: parsedFrom.name || '',

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ function parseAddresses(headers) {
     }
   
     headers.bcc = addressparser(headers.bcc);
-    for (var w = 0; w < email.bcc.length; w++) {
+    for (var w = 0; w < headers.bcc.length; w++) {
       headers.bcc[w].address = headers.bcc[w].address.toLowerCase();
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ function parseAddresses(headers) {
   if (!headers) {
     return {};
   } else {
-    console.log('parseAddresses(headers): ', headers, headers.headers);
+    console.log('parseAddresses(headers): ', headers);
     var parsedFrom = addressparser(headers.from)[0];
     headers.from = {
       name: parsedFrom.name || '',
@@ -54,7 +54,7 @@ function parseAddresses(headers) {
     }
   
     headers.cc = addressparser(headers.cc);
-    for (var w = 0; w < email.cc.length; w++) {
+    for (var w = 0; w < headers.cc.length; w++) {
       headers.cc[w].address = headers.cc[w].address.toLowerCase();
     }
   

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,8 @@ function parseAddresses(headers) {
   if (!headers) {
     return {};
   } else {
-    var parsedFrom = addressparser(headers.from)[0];
+    console.log('headers.from', headers.from);
+    var parsedFrom = addressparser(headers.from);
     headers.from = {
       name: parsedFrom.name || '',
       address: parsedFrom.address.toLowerCase()

--- a/lib/index.js
+++ b/lib/index.js
@@ -92,7 +92,7 @@ module.exports = function parseMessage(response) {
   }
 
   var headers = indexHeaders(payload.headers);
-  headers = parseAddresses(payload.headers);
+  headers = parseAddresses(headers);
   result.headers = headers;
 
   var parts = [payload];

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,9 +38,7 @@ function parseAddresses(headers) {
   if (!headers) {
     return {};
   } else {
-    console.log('parseAddresses - input: ', headers);
     var parsedFrom = addressparser(headers.from)[0];
-    console.log('parsedFrom: ', parsedFrom);    
     headers.from = {
       name: parsedFrom.name || '',
       address: parsedFrom.address.toLowerCase()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "gmail-api-parse-message",
+  "version": "2.0.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "addressparser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
+      "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y="
+    },
+    "base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gmail-api-parse-message",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Parses the response from the Gmail API's GET message method",
   "main": "lib",
   "scripts": {
@@ -10,6 +10,7 @@
   "license": "MIT",
   "repository": "EmilTholin/gmail-api-parse-message",
   "dependencies": {
-    "base-64": "^0.1.0"
+    "base-64": "^0.1.0",
+    "addressparser": "1.0.1"
   }
 }


### PR DESCRIPTION
This change converts the from / to / cc / bcc headers from a string into an object, using the package https://www.npmjs.com/package/addressparser. 

so for example instead of 'andris <andris@tr.ee>' the new email object would be [{name: "andris", address:"andris@tr.ee"}].

Since the point of parsing the email is often to extract key information such as the email address, I figured others would find this change useful.

To be clear, it's a breaking change for those choosing to use this version, so that ought to be documented if you want to accept this PR.