### PR TITLE
Parse Address Headers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,8 @@ function formatAddressHeaders(headers) {
     headers[key] = addressparser(headers[key]);
   });
   ['from'].forEach(function (key) {
-    headers[key] = headers[key][0];
+    const value = headers[key];
+    headers[key] = value && value.length > 1 ? value[0] : value;
   });
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+var addressparser = require('addressparser');
 var b64Decode = require('base-64').decode;
 
 /**
@@ -26,6 +27,17 @@ function indexHeaders(headers) {
       return result;
     }, {});
   }
+}
+
+function formatAddressHeaders(headers) {
+  if (!headers) { return; }
+
+  ['bcc', 'cc', 'from', 'to'].forEach(function (key) {
+    headers[key] = addressparser(headers[key]);
+  });
+  ['from'].forEach(function (key) {
+    headers[key] = headers[key][0];
+  });
 }
 
 /**
@@ -93,6 +105,8 @@ module.exports = function parseMessage(response) {
 
     firstPartProcessed = true;
   }
+
+  formatAddressHeaders(result.headers);
 
   return result;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,7 @@ function formatAddressHeaders(headers) {
   });
   ['from'].forEach(function (key) {
     const value = headers[key];
-    headers[key] = value && value.length > 1 ? value[0] : value;
+    headers[key] = value && value.length > 0 ? value[0] : value;
   });
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,9 +44,12 @@ function formatAddressHeaders(headers) {
  * Takes a response from the Gmail API's GET message method and extracts all
  * the relevant data.
  * @param  {object} response
+ * @param  {object} options
+ * @param  {boolean} options.formatAddressHeaders
  * @return {object}
  */
-module.exports = function parseMessage(response) {
+module.exports = function parseMessage(response, options = null) {
+  options = options || {}
   var result = {
     id: response.id,
     threadId: response.threadId,
@@ -106,7 +109,9 @@ module.exports = function parseMessage(response) {
     firstPartProcessed = true;
   }
 
-  formatAddressHeaders(result.headers);
+  if (options.formatAddressHeaders) {
+    formatAddressHeaders(result.headers);
+  }
 
   return result;
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "repository": "EmilTholin/gmail-api-parse-message",
   "dependencies": {
-    "base-64": "^0.1.0"
+    "addressparser": "1.0.1",
+    "base-64": "0.1.0"
   }
 }


### PR DESCRIPTION
* Parsing address headers into objects
* Making sure to extract first address out of "from" header
* Skipping header formatting when they are missing

I saw that there was already a similar PR recently that has been closed, this PR is different in 2 key ways:
1. The address formatting is optional, defaulting to `false`
2. The address value casing does not get edited, so original values can be reproduced