### PR TITLE
Added support for inline attachments used in html email parts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,27 @@ rp({
   //     filename: 'example.jpg',
   //     mimeType: 'image/jpeg',
   //     size: 100446,
-  //     attachmentId: '{ATTACHMENT_ID}' 
+  //     attachmentId: '{ATTACHMENT_ID}',
+  //     headers: {
+  //       content-type: 'image/jpeg; name="example.jpg"',
+  //       content-description: 'example.jpg',
+  //       content-transfer-encoding": 'base64',
+  //       content-id: '...',
+  //       ...
+  //     }
   //   }],
   //   inline: [{ 
   //     filename: 'example.png',
   //     mimeType: 'image/png',
   //     size: 5551,
-  //     attachmentId: '{ATTACHMENT_ID}' 
+  //     attachmentId: '{ATTACHMENT_ID}',
+  //     headers: {
+  //       content-type: 'image/jpeg; name="example.png"',
+  //       content-description: 'example.png',
+  //       content-transfer-encoding": 'base64',
+  //       content-id: '...',
+  //       ...
+  //     }
   //   }],
   //   headers: {
   //     subject: 'Example subject',

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ rp({
   //     size: 100446,
   //     attachmentId: '{ATTACHMENT_ID}' 
   //   }],
+  //   inline: [{ 
+  //     filename: 'example.png',
+  //     mimeType: 'image/png',
+  //     size: 5551,
+  //     attachmentId: '{ATTACHMENT_ID}' 
+  //   }],
   //   headers: {
   //     subject: 'Example subject',
   //     from: 'Example Name <example@gmail.com>',

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,7 @@ module.exports = function parseMessage(response) {
     var isHtml = part.mimeType && part.mimeType.indexOf('text/html') !== -1;
     var isPlain = part.mimeType && part.mimeType.indexOf('text/plain') !== -1;
     var isAttachment = headers['content-disposition'] && headers['content-disposition'].indexOf('attachment') !== -1;
+    var isInline = headers['content-disposition'] && headers['content-disposition'].indexOf('inline') !== -1;
 
     if (isHtml && !isAttachment) {
       result.textHtml = urlB64Decode(part.body.data);
@@ -89,7 +90,18 @@ module.exports = function parseMessage(response) {
         size: body.size,
         attachmentId: body.attachmentId
       });
+    } else if (isInline) {
+    var body = part.body;
+    if(!result.inline) {
+      result.inline = [];
     }
+    result.inline.push({
+      filename: part.filename,
+      mimeType: part.mimeType,
+      size: body.size,
+      attachmentId: body.attachmentId
+    });
+  }
 
     firstPartProcessed = true;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,7 +88,8 @@ module.exports = function parseMessage(response) {
         filename: part.filename,
         mimeType: part.mimeType,
         size: body.size,
-        attachmentId: body.attachmentId
+        attachmentId: body.attachmentId,
+        headers: indexHeaders(part.headers)
       });
     } else if (isInline) {
     var body = part.body;
@@ -99,7 +100,8 @@ module.exports = function parseMessage(response) {
       filename: part.filename,
       mimeType: part.mimeType,
       size: body.size,
-      attachmentId: body.attachmentId
+      attachmentId: body.attachmentId,
+      headers: indexHeaders(part.headers)
     });
   }
 


### PR DESCRIPTION
At the moment, inline attachments are not included as part of the parsed message. These items may be valuable to retrieve and can be treated as attachments (although it makes sense to distinguish between them).