### PR TITLE
Add check for "content-disposition" header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -72,8 +72,8 @@ module.exports = function parseMessage(response) {
 
     var isHtml = part.mimeType && part.mimeType.indexOf('text/html') !== -1;
     var isPlain = part.mimeType && part.mimeType.indexOf('text/plain') !== -1;
-    var isAttachment = headers['content-disposition'] && headers['content-disposition'].indexOf('attachment') !== -1;
-    var isInline = headers['content-disposition'] && headers['content-disposition'].indexOf('inline') !== -1;
+    var isAttachment = headers['content-disposition'] && headers['content-disposition'].toLowerCase().indexOf('attachment') !== -1;
+    var isInline = headers['content-disposition'] && headers['content-disposition'].toLowerCase().indexOf('inline') !== -1;
 
     if (isHtml && !isAttachment) {
       result.textHtml = urlB64Decode(part.body.data);


### PR DESCRIPTION
In some cases gmail api returns uppercase header value.
Example:
    Content-Disposition: ATTACHMENT; filename="8E854328.pdf"