### PR TITLE
Early return when a part has no contents

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ module.exports = function parseMessage(response) {
       headers = indexHeaders(part.headers);
     }
 
-    if (!part.body) {
+    if (!part.body.size) {
       continue;
     }
 


### PR DESCRIPTION
I think that this condition not worked before because Gmail API always returns a `part` with `body: {size: 0}` when a `part` has no contents

Apart from this why is `firstPartProcessed` need?